### PR TITLE
Fix linux mappings

### DIFF
--- a/src/components/input/GamepadController.js
+++ b/src/components/input/GamepadController.js
@@ -7,7 +7,7 @@ import {
   gamepadButtonChanged
 } from "../../store/inputSlice";
 
-const CrossPlatformLayout = {
+const crossPlatformLayout = {
   buttons: [
     "A",
     "B",
@@ -52,7 +52,7 @@ function GamepadController({ gamepadName, gamepadIndex }) {
   const dispatch = useDispatch();
   return (
     <Gamepad
-      layout={CrossPlatformLayout}
+      layout={crossPlatformLayout}
       gamepadIndex={gamepadIndex}
       onConnect={() => dispatch(gamepadConnected({ gamepadName }))}
       onDisconnect={() => dispatch(gamepadDisconnected({ gamepadName }))}

--- a/src/components/input/GamepadController.js
+++ b/src/components/input/GamepadController.js
@@ -32,7 +32,7 @@ const CrossPlatformLayout = {
     "RightStickX",
     "-RightStickY",
     "DPadX",
-    "DPadY",
+    "-DPadY",
     "LeftTrigger",
     "RightTrigger",
   ],

--- a/src/components/input/GamepadController.js
+++ b/src/components/input/GamepadController.js
@@ -7,10 +7,52 @@ import {
   gamepadButtonChanged
 } from "../../store/inputSlice";
 
+const CrossPlatformLayout = {
+  buttons: [
+    "A",
+    "B",
+    "X",
+    "Y",
+    "LB",
+    "RB",
+    "LT",
+    "RT",
+    "Back",
+    "Start",
+    "LS",
+    "RS",
+    "DPadUp",
+    "DPadDown",
+    "DPadLeft",
+    "DPadRight",
+  ],
+  axis: [
+    "LeftStickX",
+    "-LeftStickY",
+    "RightStickX",
+    "-RightStickY",
+    "DPadX",
+    "DPadY",
+    "LeftTrigger",
+    "RightTrigger",
+  ],
+  buttonAxis: [
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    "LeftTrigger",
+    "RightTrigger",
+  ],
+}
+
 function GamepadController({ gamepadName, gamepadIndex }) {
   const dispatch = useDispatch();
   return (
     <Gamepad
+      layout={CrossPlatformLayout}
       gamepadIndex={gamepadIndex}
       onConnect={() => dispatch(gamepadConnected({ gamepadName }))}
       onDisconnect={() => dispatch(gamepadDisconnected({ gamepadName }))}

--- a/src/store/inputSlice.js
+++ b/src/store/inputSlice.js
@@ -71,7 +71,15 @@ const inputSlice = createSlice({
     gamepadAxisChanged(state, action) {
       const prevState = JSON.parse(JSON.stringify(state));
       const { gamepadName, axisName, value } = action.payload;
-      state[gamepadName][axisName] = value;
+      if (axisName === "DPadX") {
+        state[gamepadName]["DPadLeft"] = value < 0;
+        state[gamepadName]["DPadRight"] = value > 0;
+      } else if (axisName === "DPadY") {
+        state[gamepadName]["DPadDown"] = value < 0;
+        state[gamepadName]["DPadUp"] = value > 0;
+      } else {
+        state[gamepadName][axisName] = value;
+      }
       computeInput(prevState, state, action);
     },
 
@@ -79,7 +87,7 @@ const inputSlice = createSlice({
       const prevState = JSON.parse(JSON.stringify(state));
       const { gamepadName, buttonName, pressed } = action.payload;
       if (buttonName === "LT" || buttonName === "RT")
-        // Treat triggers as axes, not buttons.  
+        // Treat triggers as axes, not buttons.
         return;
       state[gamepadName][buttonName] = pressed;
       computeInput(prevState, state, action);

--- a/src/store/inputSlice.js
+++ b/src/store/inputSlice.js
@@ -54,6 +54,10 @@ const initialState = {
   }
 };
 
+function isLinux() {
+  return navigator.platform.toLowerCase().includes("linux");
+}
+
 const inputSlice = createSlice({
   name: "input",
   initialState,
@@ -71,12 +75,16 @@ const inputSlice = createSlice({
     gamepadAxisChanged(state, action) {
       const prevState = JSON.parse(JSON.stringify(state));
       const { gamepadName, axisName, value } = action.payload;
+      // linux maps dpad to axes, so map them to buttons
+      // also rescale triggers from [-1,1] -> [0,1], if necessary
       if (axisName === "DPadX") {
         state[gamepadName]["DPadLeft"] = value < 0;
         state[gamepadName]["DPadRight"] = value > 0;
       } else if (axisName === "DPadY") {
         state[gamepadName]["DPadDown"] = value < 0;
         state[gamepadName]["DPadUp"] = value > 0;
+      } else if (isLinux() && (axisName === "LeftTrigger" || axisName === "RightTrigger")){
+        state[gamepadName][axisName] = (value + 1) / 2.0;
       } else {
         state[gamepadName][axisName] = value;
       }


### PR DESCRIPTION
This PR fixes the button mappings so that the gamepads will work with Linux, which represents the gamepad mappings differently. The changes should preserve the behavior on Windows as what it used to be, so this shouldn't break anything.

Things may not be organized optimally as I was just trying to get things working, so feel free to refactor as necessary.