### PR TITLE
Fix hand bug

### DIFF
--- a/src/components/input/GamepadController.js
+++ b/src/components/input/GamepadController.js
@@ -54,6 +54,7 @@ function GamepadController({ gamepadName, gamepadIndex }) {
     <Gamepad
       layout={crossPlatformLayout}
       gamepadIndex={gamepadIndex}
+      deadZone={0.0}
       onConnect={() => dispatch(gamepadConnected({ gamepadName }))}
       onDisconnect={() => dispatch(gamepadDisconnected({ gamepadName }))}
       onAxisChange={(axisName, value) => dispatch(gamepadAxisChanged({

--- a/src/store/inputSlice.js
+++ b/src/store/inputSlice.js
@@ -77,7 +77,10 @@ const inputSlice = createSlice({
       if (axisName === "DPadY") {
         state[gamepadName]["DPadDown"] = value < 0;
         state[gamepadName]["DPadUp"] = value > 0;
-      } else if (isLinux() && (axisName === "LeftTrigger" || axisName === "RightTrigger")) {
+      } else if (isLinux() && (axisName === "LeftTrigger" || axisName === "RightTrigger") && value !== 0.0) {
+        // bug in linux, trigger values keep jumping to 0.
+        // Rejecting this is ok, since it'll never be *exactly* zero, since that's halfway-pressed
+        // TODO: fix this? Why is this happening? Bug in react-gamepad??
         state[gamepadName][axisName] = (value + 1) / 2.0;
       } else {
         state[gamepadName][axisName] = value;


### PR DESCRIPTION
Linux systems had a bug where the trigger axis values were jumping back and forth to 0 (which was remapped to 0.5), which was causing the hand to twitch and close by itself. This fix is a hack that makes it work by removing the deadzone and then ignoring all commands of 0.5 power.

I suspect the underlying bug is somewhere in the gamepad library?