### PR TITLE
Fixed packet definition with latitude and longitude. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,9 +236,8 @@ Sent from the rover to inform Mission Control of the rover's current position in
   orientX: number,
   orientY: number,
   orientZ: number,
-  posX: number,
-  posY: number,
-  posZ: number,
+  lon: number,
+  lat: number,
   recency: number
 }
 ```
@@ -247,9 +246,8 @@ Sent from the rover to inform Mission Control of the rover's current position in
 - `orientX` - refers to the orientation quaternion X component
 - `orientY` - refers to the orientation quaternion Y component
 - `orientZ` - refers to the orientation quaternion Z component
-- `posX` - refers to the X position of the rover in world reference frame in meters
-- `posY` - refers to the Y position of the rover in world reference frame in meters
-- `posZ` - refers to the Z position of the rover in world reference frame in meters
+- `lon` - refers to the longitude of the rover in world reference frame in meters
+- `lat` - refers to the latitude of the rover in world reference frame in meters
 - `recency` - refers to the difference in time between when the measurement was taken and sent in seconds
 
 ## Camera Stream Open Request

--- a/src/store/middleware/telemetryMiddleware.js
+++ b/src/store/middleware/telemetryMiddleware.js
@@ -6,15 +6,14 @@ const telemetryMiddleware = store => next => action => {
   if (action.type === messageReceivedFromRover.type) {
     const { message } = action.payload;
     if (message.type === "roverPositionReport") {
-      const { orientW, orientX, orientY, orientZ, posX, posY, posZ, recency } = message;
+      const { orientW, orientX, orientY, orientZ, lon, lat, recency } = message;
       store.dispatch(roverPositionReportReceived({
         orientW,
         orientX,
         orientY,
         orientZ,
-        posX,
-        posY,
-        posZ,
+        lon,
+        lat,
         recency
       }));
     }

--- a/src/store/telemetrySlice.js
+++ b/src/store/telemetrySlice.js
@@ -5,9 +5,8 @@ const initialState = {
     orientX: null,
     orientY: null,
     orientZ: null,
-    posX: null,
-    posY: null,
-    posZ: null,
+    lon: null,
+    lat: null,
     recency: null
 }
 
@@ -16,14 +15,13 @@ const telemetrySlice = createSlice({
     initialState,
     reducers: {
         roverPositionReportReceived(state, action) {
-            const { orientW, orientX, orientY, orientZ, posX, posY, posZ, recency } = action.payload;
+            const { orientW, orientX, orientY, orientZ, lon, lat, recency } = action.payload;
             state.orientW = orientW;
             state.orientX = orientX;
             state.orientY = orientY;
             state.orientZ = orientZ;
-            state.posX = posX;
-            state.posY = posY;
-            state.posZ = posZ;
+            state.lon = lon;
+            state.lat = lat;
             state.recency = recency;
         }
     }


### PR DESCRIPTION
Replaced posx with lon and posy with lat and removed posz in Readme, telemetryslice and telemetry middleware