### PR TITLE
Added New Packets for Enabling Arm IK

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Sent from the rover server to inform Mission Control of a joint's current positi
 
 ## Request Arm IK Enabled
 ### Description
-Sent from Mission Control to instruct Rover to enable or disable inverse kinematics.  This packet is not guaranteed to enable/disable IK. An `armIKEnabledReport` packet will be sent immediately after the `requestArmIKEnabled` is processed by the rover, and this can be used to know if IK was successfully enabled/disabled. 
+Sent from Mission Control to instruct the rover to enable or disable inverse kinematics.  This packet is not guaranteed to enable/disable IK. An `armIKEnabledReport` packet will be sent immediately after the `requestArmIKEnabled` is processed by the rover, and this can be used to know if IK was successfully enabled/disabled. 
 
 ### Syntax
 ```

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The rover can be operated through Mission Control with either a keyboard or two 
 ![Armo controls](/src/components/help/armControls.png)
 ![Keyboard controls](/src/components/help/keyboardControls.png)
 
-## Messages (`v2024.0.0`)
+## Messages (`v2024.0.1`)
 The JSON objects sent between Mission Control and the rover server are termed *messages*. Each message has a type property and a number of additional parameters depending on the type. The usage of each type of message is detailed below.
 
 ## Mounted Peripheral Report

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Sent from the rover server to inform Mission Control of a joint's current positi
 
 ## Request Arm IK Enabled
 ### Description
-Sent from Mission Control to instruct Rover to enable or disable inverse kinematics.
+Sent from Mission Control to instruct Rover to enable or disable inverse kinematics.  This packet is not garunteed to enable/disable IK. An `armIKEnabledReport` packet will be sent immediately after the `requestArmIKEnabled` is processed by Rover, and this can be used to know if IK was successfully enabled/disabled. 
 
 ### Syntax
 ```

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The rover can be operated through Mission Control with either a keyboard or two 
 ![Armo controls](/src/components/help/armControls.png)
 ![Keyboard controls](/src/components/help/keyboardControls.png)
 
-## Messages (`v2024.0.1`)
+## Messages (`v2024.1.0`)
 The JSON objects sent between Mission Control and the rover server are termed *messages*. Each message has a type property and a number of additional parameters depending on the type. The usage of each type of message is detailed below.
 
 ## Mounted Peripheral Report

--- a/README.md
+++ b/README.md
@@ -218,14 +218,14 @@ Sent from Mission Control to instruct Rover to enable or disable inverse kinemat
 ### Parameters
 - `enabled` - whether or not inverse kinematics for the arm should be enabled or disabled.
 
-## Report Arm IK Enabled
+## Arm IK Enabled Report
 ### Description
 Sent from Rover to inform Mission Control whether or not the Rover has enabled or disabled inverse kinematics.
 
 ### Syntax
 ```
 {
-  type: "reportArmIKEnabled",
+  type: "armIKEnabledReport",
   enabled: boolean
 }
 ```

--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ The rover can be operated through Mission Control with either a keyboard or two 
 ![Armo controls](/src/components/help/armControls.png)
 ![Keyboard controls](/src/components/help/keyboardControls.png)
 
+<<<<<<< HEAD
 ## Messages (`v2024.0.1`)
+=======
+## Messages (`v2024.0.0`)
+>>>>>>> 22e1403 (Updated README)
 The JSON objects sent between Mission Control and the rover server are termed *messages*. Each message has a type property and a number of additional parameters depending on the type. The usage of each type of message is detailed below.
 
 ## Mounted Peripheral Report

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Sent from the rover server to inform Mission Control of a joint's current positi
 
 ## Request Arm IK Enabled
 ### Description
-Sent from Mission Control to instruct Rover to enable or disable inverse kinematics.  This packet is not garunteed to enable/disable IK. An `armIKEnabledReport` packet will be sent immediately after the `requestArmIKEnabled` is processed by Rover, and this can be used to know if IK was successfully enabled/disabled. 
+Sent from Mission Control to instruct Rover to enable or disable inverse kinematics.  This packet is not guaranteed to enable/disable IK. An `armIKEnabledReport` packet will be sent immediately after the `requestArmIKEnabled` is processed by the rover, and this can be used to know if IK was successfully enabled/disabled. 
 
 ### Syntax
 ```
@@ -220,7 +220,7 @@ Sent from Mission Control to instruct Rover to enable or disable inverse kinemat
 
 ## Arm IK Enabled Report
 ### Description
-Sent from Rover to inform Mission Control whether or not the Rover has enabled or disabled inverse kinematics.
+Sent from the rover to inform Mission Control whether or not the Rover has enabled or disabled inverse kinematics.
 
 ### Syntax
 ```

--- a/README.md
+++ b/README.md
@@ -51,11 +51,7 @@ The rover can be operated through Mission Control with either a keyboard or two 
 ![Armo controls](/src/components/help/armControls.png)
 ![Keyboard controls](/src/components/help/keyboardControls.png)
 
-<<<<<<< HEAD
 ## Messages (`v2024.0.1`)
-=======
-## Messages (`v2024.0.0`)
->>>>>>> 22e1403 (Updated README)
 The JSON objects sent between Mission Control and the rover server are termed *messages*. Each message has a type property and a number of additional parameters depending on the type. The usage of each type of message is detailed below.
 
 ## Mounted Peripheral Report

--- a/README.md
+++ b/README.md
@@ -203,20 +203,35 @@ Sent from the rover server to inform Mission Control of a joint's current positi
 - `joint` - the name of the joint
 - `position` - the current position in degrees
 
-## Set Arm IK Enabled
+## Request Arm IK Enabled
 ### Description
-Sent from Mission Control to enable or disable inverse kinematics controls on the rover.
+Sent from Mission Control to instruct Rover to enable or disable inverse kinematics.
 
 ### Syntax
 ```
 {
-  type: "setArmIKEnabled",
+  type: "requestArmIKEnabled",
   enabled: boolean
 }
 ```
 
 ### Parameters
 - `enabled` - whether or not inverse kinematics for the arm should be enabled or disabled.
+
+## Report Arm IK Enabled
+### Description
+Sent from Rover to inform Mission Control whether or not the Rover has enabled or disabled inverse kinematics.
+
+### Syntax
+```
+{
+  type: "reportArmIKEnabled",
+  enabled: boolean
+}
+```
+
+### Parameters
+- `enabled` - whether or not inverse kinematics for the arm is enabled
 
 ## Motor Status Report
 ### Description

--- a/src/components/sidebar/ToggleInverseKinematics.js
+++ b/src/components/sidebar/ToggleInverseKinematics.js
@@ -14,7 +14,7 @@ function ToggleInverseKinematics() {
         if (roverIsConnected && motorsEnabled) {
             dispatch(enableIK({ enable: !IKEnabled && window.confirm("Turning on inverse kinematics requires that the motors are calibrated.  You must be sure the motors are calibrated or the robot will break.") })); // change dispatch
         }
-    };
+    };D
 
     return (
         <div id='enable-ik-toggle'>

--- a/src/components/sidebar/ToggleInverseKinematics.js
+++ b/src/components/sidebar/ToggleInverseKinematics.js
@@ -2,6 +2,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { selectInverseKinematicsEnabled, enableIK } from "../../store/inputSlice";
 import { selectMotorsAreEnabled } from "../../store/motorsSlice";
 import { selectRoverIsConnected } from "../../store/roverSocketSlice";
+import { selectIsStopped } from '../../store/emergencyStopSlice';
 import "./ToggleInverseKinematics.css";
 
 function ToggleInverseKinematics() {
@@ -9,21 +10,22 @@ function ToggleInverseKinematics() {
     const IKEnabled = useSelector(selectInverseKinematicsEnabled);
     const motorsEnabled = useSelector(selectMotorsAreEnabled);
     const roverIsConnected = useSelector(selectRoverIsConnected);
+    const roverIsStopped = useSelector(selectIsStopped);
 
     const handleClick = () => {
-        if (roverIsConnected && motorsEnabled) {
+        if (roverIsConnected && motorsEnabled && !roverIsStopped) {
             dispatch(enableIK({ enable: !IKEnabled && window.confirm("Turning on inverse kinematics requires that the motors are calibrated.  You must be sure the motors are calibrated or the robot will break.") })); // change dispatch
         }
     };
 
     return (
         <div id='enable-ik-toggle'>
-            <div id={motorsEnabled ? 'enable-ik-title' : 'enable-ik-title-disabled'}>
+            <div id={motorsEnabled && !roverIsStopped ? 'enable-ik-title' : 'enable-ik-title-disabled'}>
                 Enable IK
             </div>
             <div id='switch-wrapper' onClick={handleClick}>
                 <div id={IKEnabled ? 'disable-ik' : 'enable-ik'} className='ik-switch'>
-                    <div id={IKEnabled ? 'disable-ik-handle' : 'enable-ik-handle'} className={roverIsConnected ? 'switch-handle' : ' switch-handle-disconnected'}>
+                    <div id={IKEnabled ? 'disable-ik-handle' : 'enable-ik-handle'} className={roverIsConnected && !roverIsStopped ? 'switch-handle' : ' switch-handle-disconnected'}>
                     </div>
                 </div>
             </div>

--- a/src/components/sidebar/ToggleInverseKinematics.js
+++ b/src/components/sidebar/ToggleInverseKinematics.js
@@ -14,7 +14,7 @@ function ToggleInverseKinematics() {
         if (roverIsConnected && motorsEnabled) {
             dispatch(enableIK({ enable: !IKEnabled && window.confirm("Turning on inverse kinematics requires that the motors are calibrated.  You must be sure the motors are calibrated or the robot will break.") })); // change dispatch
         }
-    };D
+    };
 
     return (
         <div id='enable-ik-toggle'>

--- a/src/components/sidebar/ToggleInverseKinematics.js
+++ b/src/components/sidebar/ToggleInverseKinematics.js
@@ -21,9 +21,9 @@ function ToggleInverseKinematics() {
             <div id={motorsEnabled ? 'enable-ik-title' : 'enable-ik-title-disabled'}>
                 Enable IK
             </div>
-            <div id={roverIsConnected && motorsEnabled ? 'switch-wrapper' : 'switch-wrapper-disabled'} onClick={handleClick}>
-                <div id={ IKEnabled ? 'disable-ik' : 'enable-ik'} className='ik-switch'>
-                    <div id={IKEnabled ? 'disable-ik-handle' : 'enable-ik-handle'} className={roverIsConnected && motorsEnabled ? 'switch-handle' : ' switch-handle-disconnected'}>
+            <div id='switch-wrapper' onClick={handleClick}>
+                <div id={IKEnabled ? 'disable-ik' : 'enable-ik'} className='ik-switch'>
+                    <div id={IKEnabled ? 'disable-ik-handle' : 'enable-ik-handle'} className={roverIsConnected ? 'switch-handle' : ' switch-handle-disconnected'}>
                     </div>
                 </div>
             </div>

--- a/src/components/sidebar/ToggleInverseKinematics.js
+++ b/src/components/sidebar/ToggleInverseKinematics.js
@@ -20,7 +20,7 @@ function ToggleInverseKinematics() {
 
     return (
         <div id='enable-ik-toggle'>
-            <div id={motorsEnabled && !roverIsStopped ? 'enable-ik-title' : 'enable-ik-title-disabled'}>
+            <div id={motorsEnabled && !roverIsStopped && roverIsConnected ? 'enable-ik-title' : 'enable-ik-title-disabled'}>
                 Enable IK
             </div>
             <div id='switch-wrapper' onClick={handleClick}>

--- a/src/store/inputSlice.js
+++ b/src/store/inputSlice.js
@@ -124,6 +124,10 @@ const inputSlice = createSlice({
     },
 
     enableIK(state, action) {
+
+    },
+
+    visuallyEnableIK(state, action) {
       const { enable } = action.payload;
       state.inverseKinematics.enabled = enable;
     }
@@ -271,7 +275,8 @@ export const {
   gamepadButtonChanged,
   keyPressed,
   keyReleased,
-  enableIK
+  enableIK,
+  visuallyEnableIK
 } = inputSlice.actions;
 
 export const selectInputDeviceIsConnected = deviceName => state => state.input[deviceName].isConnected;

--- a/src/store/inputSlice.js
+++ b/src/store/inputSlice.js
@@ -128,7 +128,7 @@ const inputSlice = createSlice({
     },
 
     visuallyEnableIK(state, action) {
-      const { enable } = action.payload;
+      const enable = action.payload;
       state.inverseKinematics.enabled = enable;
     }
   }

--- a/src/store/inputSlice.js
+++ b/src/store/inputSlice.js
@@ -54,7 +54,7 @@ const initialState = {
   },
   inverseKinematics: {
     enabled: false,
-    lastSentArmIKState: false
+    lastSentArmIKState: null
   }
 };
 

--- a/src/store/inputSlice.js
+++ b/src/store/inputSlice.js
@@ -53,7 +53,8 @@ const initialState = {
     }
   },
   inverseKinematics: {
-    enabled: false
+    enabled: false,
+    lastSentArmIKState: false
   }
 };
 
@@ -124,7 +125,7 @@ const inputSlice = createSlice({
     },
 
     enableIK(state, action) {
-
+      state.inverseKinematics.lastSentArmIKState = action.payload.enable;
     },
 
     visuallyEnableIK(state, action) {

--- a/src/store/middleware/inputMiddleware.js
+++ b/src/store/middleware/inputMiddleware.js
@@ -3,7 +3,7 @@ import { requestDrive, requestTankDrive } from "../driveSlice";
 import { requestLazySusanPosition } from "../scienceSlice";
 import { requestJointPower } from "../jointsSlice";
 import { enableIK } from "../inputSlice";
-import { messageRover, roverDisconnected, roverConnected } from "../roverSocketSlice";
+import { messageReceivedFromRover, messageRover, roverDisconnected, roverConnected } from "../roverSocketSlice";
 /**
  * Middleware that messages the rover in response to user input.
  */
@@ -41,6 +41,16 @@ const inputMiddleware = store => next => action => {
         break;
       }
 
+      case messageReceivedFromRover.type: {
+        const { message } = action.payload;
+        if (message.type === "armIKEnabledReport") {
+          if (message.enabled == store.getState().input.inverseKinematics.enabled) {
+            alert("Arm IK was unable to be " + (!message.enabled ? "enabled." : "disabled."));
+          }
+          store.dispatch(enableIK(message.enabled));
+        }
+        break;
+      }
       default: break;
     }
     return next(action);

--- a/src/store/middleware/inputMiddleware.js
+++ b/src/store/middleware/inputMiddleware.js
@@ -44,10 +44,17 @@ const inputMiddleware = store => next => action => {
       case messageReceivedFromRover.type: {
         const { message } = action.payload;
         if (message.type === "armIKEnabledReport") {
+<<<<<<< HEAD
           if (store.getState().input.inverseKinematics.lastSentArmIKState !== null && store.getState().input.inverseKinematics.lastSentArmIKState !== message.enabled) {
             alert("Arm IK was unable to be " + (!message.enabled ? "enabled." : "disabled."));
           }
           store.dispatch(visuallyEnableIK(message.enabled));
+=======
+          if (message.enabled == store.getState().input.inverseKinematics.enabled) {
+            alert("Arm IK was unable to be " + (!message.enabled ? "enabled." : "disabled."));
+          }
+          store.dispatch(enableIK(message.enabled));
+>>>>>>> e36e961 (Handling armIKEnabledReport)
         }
         break;
       }

--- a/src/store/middleware/inputMiddleware.js
+++ b/src/store/middleware/inputMiddleware.js
@@ -44,17 +44,10 @@ const inputMiddleware = store => next => action => {
       case messageReceivedFromRover.type: {
         const { message } = action.payload;
         if (message.type === "armIKEnabledReport") {
-<<<<<<< HEAD
           if (store.getState().input.inverseKinematics.lastSentArmIKState !== null && store.getState().input.inverseKinematics.lastSentArmIKState !== message.enabled) {
             alert("Arm IK was unable to be " + (!message.enabled ? "enabled." : "disabled."));
           }
           store.dispatch(visuallyEnableIK(message.enabled));
-=======
-          if (message.enabled == store.getState().input.inverseKinematics.enabled) {
-            alert("Arm IK was unable to be " + (!message.enabled ? "enabled." : "disabled."));
-          }
-          store.dispatch(enableIK(message.enabled));
->>>>>>> e36e961 (Handling armIKEnabledReport)
         }
         break;
       }

--- a/src/store/middleware/inputMiddleware.js
+++ b/src/store/middleware/inputMiddleware.js
@@ -44,7 +44,8 @@ const inputMiddleware = store => next => action => {
       case messageReceivedFromRover.type: {
         const { message } = action.payload;
         if (message.type === "armIKEnabledReport") {
-          if (message.enabled === store.getState().input.inverseKinematics.enabled) {
+          console.log(store.getState().input.inverseKinematics.lastSentArmIKState);
+          if (store.getState().input.inverseKinematics.lastSentArmIKState !== message.enabled) {
             alert("Arm IK was unable to be " + (!message.enabled ? "enabled." : "disabled."));
           }
           store.dispatch(visuallyEnableIK(message.enabled));

--- a/src/store/middleware/inputMiddleware.js
+++ b/src/store/middleware/inputMiddleware.js
@@ -12,7 +12,7 @@ const inputMiddleware = store => next => action => {
     if (action.type === enableIK.type) {
       store.dispatch(messageRover({
         message: {
-          type: "setArmIKEnabled",
+          type: "requestArmIKEnabled",
           enabled: action.payload.enable
         }
       }));

--- a/src/store/middleware/inputMiddleware.js
+++ b/src/store/middleware/inputMiddleware.js
@@ -44,7 +44,7 @@ const inputMiddleware = store => next => action => {
       case messageReceivedFromRover.type: {
         const { message } = action.payload;
         if (message.type === "armIKEnabledReport") {
-          if (message.enabled == store.getState().input.inverseKinematics.enabled) {
+          if (message.enabled === store.getState().input.inverseKinematics.enabled) {
             alert("Arm IK was unable to be " + (!message.enabled ? "enabled." : "disabled."));
           }
           store.dispatch(visuallyEnableIK(message.enabled));

--- a/src/store/middleware/inputMiddleware.js
+++ b/src/store/middleware/inputMiddleware.js
@@ -44,7 +44,8 @@ const inputMiddleware = store => next => action => {
       case messageReceivedFromRover.type: {
         const { message } = action.payload;
         if (message.type === "armIKEnabledReport") {
-          if (store.getState().input.inverseKinematics.lastSentArmIKState !== null && store.getState().input.inverseKinematics.lastSentArmIKState !== message.enabled) {
+          let lastArmIKState = store.getState().input.inverseKinematics.lastSentArmIKState;
+          if (lastArmIKState !== null && lastArmIKState !== message.enabled) {
             alert("Arm IK was unable to be " + (!message.enabled ? "enabled." : "disabled."));
           }
           store.dispatch(visuallyEnableIK(message.enabled));

--- a/src/store/middleware/inputMiddleware.js
+++ b/src/store/middleware/inputMiddleware.js
@@ -44,7 +44,7 @@ const inputMiddleware = store => next => action => {
       case messageReceivedFromRover.type: {
         const { message } = action.payload;
         if (message.type === "armIKEnabledReport") {
-          if (store.getState().input.inverseKinematics.lastSentArmIKState !== message.enabled) {
+          if (store.getState().input.inverseKinematics.lastSentArmIKState !== null && store.getState().input.inverseKinematics.lastSentArmIKState !== message.enabled) {
             alert("Arm IK was unable to be " + (!message.enabled ? "enabled." : "disabled."));
           }
           store.dispatch(visuallyEnableIK(message.enabled));

--- a/src/store/middleware/inputMiddleware.js
+++ b/src/store/middleware/inputMiddleware.js
@@ -2,7 +2,7 @@ import { selectMountedPeripheral } from "../peripheralsSlice";
 import { requestDrive, requestTankDrive } from "../driveSlice";
 import { requestLazySusanPosition } from "../scienceSlice";
 import { requestJointPower } from "../jointsSlice";
-import { enableIK } from "../inputSlice";
+import { enableIK, visuallyEnableIK } from "../inputSlice";
 import { messageReceivedFromRover, messageRover, roverDisconnected, roverConnected } from "../roverSocketSlice";
 /**
  * Middleware that messages the rover in response to user input.
@@ -47,7 +47,7 @@ const inputMiddleware = store => next => action => {
           if (message.enabled == store.getState().input.inverseKinematics.enabled) {
             alert("Arm IK was unable to be " + (!message.enabled ? "enabled." : "disabled."));
           }
-          store.dispatch(enableIK(message.enabled));
+          store.dispatch(visuallyEnableIK(message.enabled));
         }
         break;
       }

--- a/src/store/middleware/inputMiddleware.js
+++ b/src/store/middleware/inputMiddleware.js
@@ -44,7 +44,6 @@ const inputMiddleware = store => next => action => {
       case messageReceivedFromRover.type: {
         const { message } = action.payload;
         if (message.type === "armIKEnabledReport") {
-          console.log(store.getState().input.inverseKinematics.lastSentArmIKState);
           if (store.getState().input.inverseKinematics.lastSentArmIKState !== message.enabled) {
             alert("Arm IK was unable to be " + (!message.enabled ? "enabled." : "disabled."));
           }


### PR DESCRIPTION
Changed "setArmIKEnabled" to "requestArmIKEnabled".
Added "armIKEnabledReport".
Mission Control will now receive a packet from Rover letting it know if it successfully enabled inverse kinematics for the arm.