### PR TITLE
Added More Disabled Visuals for Arm IK Enable Switch

### DIFF
--- a/src/components/sidebar/ToggleInverseKinematics.css
+++ b/src/components/sidebar/ToggleInverseKinematics.css
@@ -14,9 +14,23 @@
     margin-bottom: 5px;
 }
 
+#enable-ik-title-disabled {
+    color: gray;
+    font-weight: bold;
+    font-size: 22px;
+    margin-bottom: 5px;
+}
+
 #switch-wrapper {
     width: 100px;
     height: 30px;
+    cursor: pointer;
+}
+
+#switch-wrapper-disabled {
+    width: 100px;
+    height: 30px;
+    cursor: not-allowed;
 }
 
 #enable-ik {

--- a/src/components/sidebar/ToggleInverseKinematics.js
+++ b/src/components/sidebar/ToggleInverseKinematics.js
@@ -1,27 +1,29 @@
 import { useDispatch, useSelector } from "react-redux";
 import { selectInverseKinematicsEnabled, enableIK } from "../../store/inputSlice";
+import { selectMotorsAreEnabled } from "../../store/motorsSlice";
 import { selectRoverIsConnected } from "../../store/roverSocketSlice";
 import "./ToggleInverseKinematics.css";
 
 function ToggleInverseKinematics() {
     const dispatch = useDispatch();
     const IKEnabled = useSelector(selectInverseKinematicsEnabled);
+    const motorsEnabled = useSelector(selectMotorsAreEnabled);
     const roverIsConnected = useSelector(selectRoverIsConnected);
 
     const handleClick = () => {
-        if (roverIsConnected) {
+        if (roverIsConnected && motorsEnabled) {
             dispatch(enableIK({ enable: !IKEnabled && window.confirm("Turning on inverse kinematics requires that the motors are calibrated.  You must be sure the motors are calibrated or the robot will break.") })); // change dispatch
         }
     };
 
     return (
         <div id='enable-ik-toggle'>
-            <div id='enable-ik-title'>
+            <div id={motorsEnabled ? 'enable-ik-title' : 'enable-ik-title-disabled'}>
                 Enable IK
             </div>
-            <div id='switch-wrapper' onClick={handleClick}>
+            <div id={roverIsConnected && motorsEnabled ? 'switch-wrapper' : 'switch-wrapper-disabled'} onClick={handleClick}>
                 <div id={ IKEnabled ? 'disable-ik' : 'enable-ik'} className='ik-switch'>
-                    <div id={IKEnabled ? 'disable-ik-handle' : 'enable-ik-handle'} className={roverIsConnected ? 'switch-handle' : ' switch-handle-disconnected'}>
+                    <div id={IKEnabled ? 'disable-ik-handle' : 'enable-ik-handle'} className={roverIsConnected && motorsEnabled ? 'switch-handle' : ' switch-handle-disconnected'}>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
- No longer possible to enable IK when motors are disabled.
- Changed cursor for switch.  'pointer' when enabled, 'not-allowed' when disabled.
- Changed title color when switch cannot be flipped.