### PR TITLE
Fix bug where connecting to rover would fail in new versions of chrome

### DIFF
--- a/src/store/middleware/roverSocketMiddleware.js
+++ b/src/store/middleware/roverSocketMiddleware.js
@@ -14,11 +14,16 @@ import {
  */
 const roverSocketMiddleware = () => {
   let socket = null;
+  let isConnecting = false;
 
-  const onOpen = store => () => store.dispatch(roverConnected());
+  const onOpen = store => () => {
+    isConnecting = false;
+    store.dispatch(roverConnected());
+  }
 
   const onClose = store => () => {
     socket = null;
+    isConnecting = false;
     store.dispatch(roverDisconnected());
   };
 
@@ -32,12 +37,16 @@ const roverSocketMiddleware = () => {
 
     switch (action.type) {
       case connectToRover.type: {
-        if (socket && socket.readyState !== WebSocket.CLOSED)
-          socket.close();
-        socket = new WebSocket(ROVER_SERVER_URL);
-        socket.onmessage = onMessage(store);
-        socket.onclose = onClose(store);
-        socket.onopen = onOpen(store);
+        if (!isConnecting) {
+          if (socket && socket.readyState !== WebSocket.CLOSED) {
+            socket.close();
+          }
+          isConnecting = true;
+          socket = new WebSocket(ROVER_SERVER_URL);
+          socket.onmessage = onMessage(store);
+          socket.onclose = onClose(store);
+          socket.onopen = onOpen(store);
+        }
         break;
       }
 


### PR DESCRIPTION
New versions of chrome trigger this bug, whereas it worked before. There was a race condition where when two connection actions were dispatched back-to-back (which always happens on mount for some reason), which was causing the middleware to create 2 websockets, one of which connected (but then got immediately replaced) and the other (and all future ones) are then rejected by the rover since the first one had already connected.

This PR fixes that by just keeping track of if the socket is currently connecting, and not processing duplicate actions in the middleware.