### PR TITLE
Refactored Camera Stream FPS Calculation to Fix FPS Spikes

### DIFF
--- a/src/components/camera/CameraStream.js
+++ b/src/components/camera/CameraStream.js
@@ -55,13 +55,13 @@ function CameraStream({ cameraName }) {
           video: new Uint8Array(frameDataArray[i])
         });
       }
-      let time = document.getElementById(vidTag.props.id).currentTime;
-      setLastFrameTime(document.getElementById(vidTag.props.id).currentTime);
-      if (time !== lastFrameTime) {
+      
+      if (Date.now() !== lastFrameTime) {
         setCurrentFpsAvg((oldFps) => {
-          return (oldFps + (1 / ((time - lastFrameTime)))) / 2;
+          return (oldFps + 1 / ((Date.now() - lastFrameTime) / 1000)) / 2;
         });
       }
+      setLastFrameTime(Date.now()); // current time in ms
     }
     // eslint-disable-next-line
   }, [frameDataArray]);


### PR DESCRIPTION
Instead of using the video tag's current time, it now uses the Date.now() to calculate time difference between frames.