### PR TITLE
Fix assembly of nav request message

### DIFF
--- a/src/store/waypointNavSlice.js
+++ b/src/store/waypointNavSlice.js
@@ -11,13 +11,13 @@ const waypointNavSlice = createSlice({
   name: "waypointNav",
   initialState,
   reducers: {
-      requestWaypointNav(state, action) {
-          const { latitude, longitude, approximate, gated } = action.payload;
-          state.latitude = latitude;
-          state.longitude = longitude;
-          state.approximate = approximate;
-          state.gated = gated;
-      }
+    requestWaypointNav(state, action) {
+      const { latitude, longitude, approximate, gated } = action.payload;
+      state.latitude = typeof latitude == "string" ? Number.parseFloat(latitude) : latitude;
+      state.longitude = typeof longitude == "string" ? Number.parseFloat(longitude) : longitude;
+      state.approximate = !!approximate;
+      state.gated = !!gated;
+    }
   }
 });
 


### PR DESCRIPTION
Previously this had a few problems where the types of objects weren't right. I.e. instead of false booleans were null, and the number-valued properties were actually strings. This fixes all that.