### PR TITLE
Fix field names in waypoint nav request

### DIFF
--- a/src/store/waypointNavSlice.js
+++ b/src/store/waypointNavSlice.js
@@ -3,8 +3,8 @@ import { createSlice } from "@reduxjs/toolkit";
 const initialState = {
   latitude: 0,
   longitude: 0,
-  approximate: false,
-  gated: false,
+  isApproximate: false,
+  isGate: false,
 };
 
 const waypointNavSlice = createSlice({
@@ -12,11 +12,11 @@ const waypointNavSlice = createSlice({
   initialState,
   reducers: {
     requestWaypointNav(state, action) {
-      const { latitude, longitude, approximate, gated } = action.payload;
+      const { latitude, longitude, isApproximate, isGate } = action.payload;
       state.latitude = typeof latitude == "string" ? Number.parseFloat(latitude) : latitude;
       state.longitude = typeof longitude == "string" ? Number.parseFloat(longitude) : longitude;
-      state.approximate = !!approximate;
-      state.gated = !!gated;
+      state.isApproximate = !!isApproximate;
+      state.isGate = !!isGate;
     }
   }
 });


### PR DESCRIPTION
The form was being submitted with fields `isXXX`, but the event handler was looking for the field `XXX`, so even if it was specified the value wouldn't be found. I believe this is the actual cause of one of the bugs "fixed" by #51 (although that fix is still good to have).

With this PR, the values should be being passed all the way from the form to the rover, and also agree with the definition from the MC protocol.