### PR TITLE
Update IK Switch Styling

### DIFF
--- a/src/components/sidebar/ToggleInverseKinematics.css
+++ b/src/components/sidebar/ToggleInverseKinematics.css
@@ -46,9 +46,14 @@
     height: 100%;
     border-radius: 100px;
     outline: 2px solid white;
+    box-sizing: border-box;
     display: flex;
     flex-direction: column;
     justify-content: center;
+}
+
+.ik-switch-disconnected {
+    outline: 2px solid rgb(68, 68, 68);
 }
 
 #enable-ik-handle {
@@ -65,8 +70,9 @@
     border-radius: 28px;
     margin-left: 2px;
     margin-right: 2px;
-    background-color: darkgray;
-    border: 1px solid white;
+    background-color: rgb(68, 68, 68);
+    border: 3px solid rgb(39, 39, 39);
+    box-sizing: border-box;
 }
 
 .switch-handle {

--- a/src/components/sidebar/ToggleInverseKinematics.css
+++ b/src/components/sidebar/ToggleInverseKinematics.css
@@ -46,7 +46,6 @@
     height: 100%;
     border-radius: 100px;
     outline: 2px solid white;
-    box-sizing: border-box;
     display: flex;
     flex-direction: column;
     justify-content: center;

--- a/src/components/sidebar/ToggleInverseKinematics.jsx
+++ b/src/components/sidebar/ToggleInverseKinematics.jsx
@@ -30,8 +30,8 @@ function ToggleInverseKinematics() {
                 Enable IK
             </div>
             <div id={canBeEnabled ? 'switch-wrapper' : 'switch-wrapper-disabled'} onClick={handleClick}>
-                <div id={IKEnabled ? 'disable-ik' : 'enable-ik'} className='ik-switch'>
-                    <div id={IKEnabled ? 'disable-ik-handle' : 'enable-ik-handle'} className={roverIsConnected && !roverIsStopped ? 'switch-handle' : ' switch-handle-disconnected'}>
+                <div id={IKEnabled ? 'disable-ik' : 'enable-ik'} className={`ik-switch ${!canBeEnabled && 'ik-switch-disconnected'}`}>
+                    <div id={IKEnabled ? 'disable-ik-handle' : 'enable-ik-handle'} className={canBeEnabled ? 'switch-handle' : ' switch-handle-disconnected'}>
                     </div>
                 </div>
             </div>

--- a/src/components/sidebar/ToggleInverseKinematics.jsx
+++ b/src/components/sidebar/ToggleInverseKinematics.jsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { selectInverseKinematicsEnabled, enableIK } from "../../store/inputSlice";
 import { selectMotorsAreEnabled } from "../../store/motorsSlice";
@@ -11,19 +12,24 @@ function ToggleInverseKinematics() {
     const motorsEnabled = useSelector(selectMotorsAreEnabled);
     const roverIsConnected = useSelector(selectRoverIsConnected);
     const roverIsStopped = useSelector(selectIsStopped);
+    const [canBeEnabled, setCanBeEnabled] = useState(false);
+
+    useEffect(() => {
+        setCanBeEnabled(roverIsConnected && motorsEnabled && !roverIsStopped);
+    }, [roverIsConnected, motorsEnabled, roverIsStopped]);
 
     const handleClick = () => {
-        if (roverIsConnected && motorsEnabled && !roverIsStopped) {
+        if (canBeEnabled) {
             dispatch(enableIK({ enable: !IKEnabled && window.confirm("Turning on inverse kinematics requires that the motors are calibrated.  You must be sure the motors are calibrated or the robot will break.") })); // change dispatch
         }
     };
 
     return (
         <div id='enable-ik-toggle'>
-            <div id={motorsEnabled && !roverIsStopped && roverIsConnected ? 'enable-ik-title' : 'enable-ik-title-disabled'}>
+            <div id={canBeEnabled ? 'enable-ik-title' : 'enable-ik-title-disabled'}>
                 Enable IK
             </div>
-            <div id='switch-wrapper' onClick={handleClick}>
+            <div id={canBeEnabled ? 'switch-wrapper' : 'switch-wrapper-disabled'} onClick={handleClick}>
                 <div id={IKEnabled ? 'disable-ik' : 'enable-ik'} className='ik-switch'>
                     <div id={IKEnabled ? 'disable-ik-handle' : 'enable-ik-handle'} className={roverIsConnected && !roverIsStopped ? 'switch-handle' : ' switch-handle-disconnected'}>
                     </div>


### PR DESCRIPTION
Changed the cursor type to "not-allowed" when hovering over ik switch in states where it cannot be enabled.
Changed the theme of the switch to be even darker when it cannot be enabled.