### PR TITLE
Changed the names of the cameras

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ Sent from Mission Control to instruct the rover server to begin providing a came
 ```
 
 ### Parameters
-- `camera` - the name of the camera
+- `camera` - the name of the camera: `mast|hand|wrist`
 - `fps` - the frame rate of the camera stream as an integer
 
 
@@ -312,7 +312,7 @@ Sent from Mission Control to instruct the rover server to stop providing a camer
 ```
 
 ### Parameters
-- `camera` - the name of the camera
+- `camera` - the name of the camera: `mast|hand|wrist`
 
 ## Camera Stream Report
 ### Description
@@ -328,7 +328,7 @@ Sent from the rover server to inform Mission Control of a single frame of a came
 ```
 
 ### Parameters
-- `camera` - the name of the camera
+- `camera` - the name of the camera: `mast|hand|wrist`
 - `data` - the raw h264 frame data, or `null` if no data is available
 
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The rover can be operated through Mission Control with either a keyboard or two 
 ![Armo controls](/src/components/help/armControls.png)
 ![Keyboard controls](/src/components/help/keyboardControls.png)
 
-## Messages (`v2024.1.1`)
+## Messages (`v2024.1.2`)
 The JSON objects sent between Mission Control and the rover server are termed *messages*. Each message has a type property and a number of additional parameters depending on the type. The usage of each type of message is detailed below.
 
 ## Mounted Peripheral Report

--- a/src/components/armDexterity/ArmDexterityPanel.jsx
+++ b/src/components/armDexterity/ArmDexterityPanel.jsx
@@ -6,10 +6,10 @@ import "./ArmDexterityPanel.css"
 function ArmDexterityPanel() {
   return (
     <div className="arm-dexterity-panel">
-      <RoverModel />
       <CameraStream cameraName="hand" />
       <CameraStream cameraName="wrist" />
-      {/* <CameraStream cameraName="mast" /> */}
+      <CameraStream cameraName="mast" />
+      <RoverModel />
     </div>
   );
 }

--- a/src/components/armDexterity/ArmDexterityPanel.jsx
+++ b/src/components/armDexterity/ArmDexterityPanel.jsx
@@ -7,8 +7,9 @@ function ArmDexterityPanel() {
   return (
     <div className="arm-dexterity-panel">
       <RoverModel />
-      <CameraStream cameraName="upperArm" />
-      <CameraStream cameraName="front" />
+      <CameraStream cameraName="hand" />
+      <CameraStream cameraName="wrist" />
+      {/* <CameraStream cameraName="mast" /> */}
     </div>
   );
 }

--- a/src/components/navigation/NavigationPanel.jsx
+++ b/src/components/navigation/NavigationPanel.jsx
@@ -7,8 +7,8 @@ import "./NavigationPanel.css"
 function NavigationPanel() {
   return (
     <div className="navigation-panel">
-      <CameraStream cameraName="front" />
-      <CameraStream cameraName="rear" />
+      <CameraStream cameraName="hand" />
+      <CameraStream cameraName="mast" />
       <Compass />
       <OpModeSelect />
       <WaypointNav />

--- a/src/components/science/SciencePanel.jsx
+++ b/src/components/science/SciencePanel.jsx
@@ -5,11 +5,11 @@ import "./SciencePanel.css"
 function ArmDexterityPanel() {
   return (
     <div className="science-panel">
-      <CameraStream cameraName="microscope" />
-      {/* placeholder microscope cameras, will replace with other science feeds */}
-      <CameraStream cameraName="microscope" />
-      <CameraStream cameraName="microscope" />
-      <CameraStream cameraName="microscope" />
+      <CameraStream cameraName="mast" />
+      {/* placeholder cameras, will replace with other science feeds */}
+      <CameraStream cameraName="mast" />
+      <CameraStream cameraName="hand" />
+      <CameraStream cameraName="wrist" />
     </div>
   );
 }

--- a/src/store/camerasSlice.js
+++ b/src/store/camerasSlice.js
@@ -1,6 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit"
 
-const cameraNames = ["front", "rear", "upperArm", "microscope"];
+const cameraNames = ["mast", "hand", "wrist"];
+// const cameraNames = ["front", "rear", "upperArm", "microscope"];
 
 const initialState = cameraNames.reduce((state, cameraName) => ({
   ...state,

--- a/src/store/camerasSlice.js
+++ b/src/store/camerasSlice.js
@@ -1,7 +1,6 @@
 import { createSlice } from "@reduxjs/toolkit"
 
 const cameraNames = ["mast", "hand", "wrist"];
-// const cameraNames = ["front", "rear", "upperArm", "microscope"];
 
 const initialState = cameraNames.reduce((state, cameraName) => ({
   ...state,


### PR DESCRIPTION
Related to: https://github.com/huskyroboticsteam/Resurgence/pull/325 and https://github.com/huskyroboticsteam/Simulator/pull/18
Changed the names of the cameras:
- `upperArm` -> `mast`
- `rear` -> `wrist`
- `front` -> `hand`